### PR TITLE
Remove floating elements from multiple pages for cleaner layout

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -170,12 +170,6 @@ export default function AboutPage() {
       </section>
 
       <WaveSVG />
-
-      {/* Floating Elements */}
-      <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none">
-        <div className="absolute top-20 left-[10%] w-16 h-16 bg-azure/10 dark:bg-gold/10 rounded-full animate-float-slow" />
-        <div className="absolute top-40 right-[15%] w-20 h-20 bg-turquoise/10 dark:bg-orange/10 rounded-full animate-float-slower" />
-      </div>
     </main>
   );
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -205,12 +205,6 @@ export default function ContactPage() {
       </div>
 
       <WaveSVG />
-
-      {/* Floating Elements */}
-      <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none">
-        <div className="absolute top-20 left-[10%] w-16 h-16 bg-[#2596be]/10 rounded-full animate-float-slow" />
-        <div className="absolute top-40 right-[15%] w-20 h-20 bg-[#80cccc]/10 rounded-full animate-float-slower" />
-      </div>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -234,18 +234,7 @@ export default function Home() {
           </Button>
         </div>
       </section>
-
       <WaveSVG />
-
-      {/* Floating Elements */}
-      <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none">
-        <div className="absolute top-20 left-[10%] w-16 h-16 bg-[#49c4c242] dark:bg-gold/10 rounded-full animate-float-slow"></div>
-        <div className="absolute top-40 right-[15%] w-20 h-20 bg-[#49c4c242] dark:bg-orange/10 rounded-full animate-float-slower"></div>
-        <div className="absolute top-60 left-[30%] w-12 h-12 bg-[#49c4c242] dark:bg-gold/10 rounded-full animate-float-slow"></div>
-        <div className="absolute top-80 right-[25%] w-24 h-24 bg-[#49c4c242] dark:bg-orange/10 rounded-full animate-float-slow"></div>
-        <div className="absolute top-96 left-[50%] w-10 h-10 bg-[#49c4c242] dark:bg-gold/10 rounded-full animate-float-slow"></div>
-        <div className="absolute top-112 right-[35%] w-18 h-18 bg-[#49c4c242] dark:bg-orange/10 rounded-full animate-float-slow"></div>
-      </div>
     </main>
   );
 }

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -157,12 +157,6 @@ export default function ProjectsPage() {
       </div>
 
       <WaveSVG />
-
-      {/* Floating Elements */}
-      <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none">
-        <div className="absolute top-20 left-[10%] w-16 h-16 bg-[#2596be]/10 rounded-full animate-float-slow" />
-        <div className="absolute top-40 right-[15%] w-20 h-20 bg-[#80cccc]/10 rounded-full animate-float-slower" />
-      </div>
     </main>
   );
 }

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -125,12 +125,6 @@ export default function ServicesPage() {
       </section>
 
       <WaveSVG />
-
-      {/* Floating Elements */}
-      <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none">
-        <div className="absolute top-20 left-[10%] w-16 h-16 bg-azure/10 dark:bg-gold/10 rounded-full animate-float-slow" />
-        <div className="absolute top-40 right-[15%] w-20 h-20 bg-turquoise/10 dark:bg-orange/10 rounded-full animate-float-slower" />
-      </div>
     </main>
   );
 }


### PR DESCRIPTION
This pull request includes changes to remove floating elements from several pages in the application. The floating elements were previously used for decorative purposes but have now been removed to simplify the design.

Removal of floating elements:

* [`src/app/about/page.tsx`](diffhunk://#diff-d38aaae18142756b8b93ec0043df16888550dfded455e182cc0e4a81eb8286e2L173-L178): Removed floating elements from the About page.
* [`src/app/contact/page.tsx`](diffhunk://#diff-c3f0df4f640dbcbe760f63e67897f06426a14e4917bdff36825c97c52cc1621fL208-L213): Removed floating elements from the Contact page.
* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL237-L248): Removed floating elements from the Home page.
* [`src/app/products/page.tsx`](diffhunk://#diff-c4795581d93b787b04d3b802a7d5093b6300f4487fb07a5426cc9df5aa70a20eL160-L165): Removed floating elements from the Projects page.
* [`src/app/services/page.tsx`](diffhunk://#diff-9dc049dbbd3dd01db2599e165c2decde8fde33a69d77aab6a8f10b97ce8a6861L128-L133): Removed floating elements from the Services page.