### PR TITLE
Fix navigation link from /projects to /products

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,7 @@ export default function Home() {
               Get Started <ArrowRight className="ml-2" />
             </Button>
           </Link>
-          <Link href="/projects">
+          <Link href="/products">
             <Button
               variant="outline"
               className="px-8 py-6 text-lg bg-white dark:text-black"


### PR DESCRIPTION
## What changed
Fixed broken link in hero section of home page - changed `/projects` to `/products` for the "View Our Work" button.

## Why
The "View Our Work" button was linking to `/projects`, which doesn't exist in the codebase. The correct route is `/products`, causing users to encounter a 404 error when clicking the button. This fix ensures users can properly navigate to the products page.

---

This PR was created by [Graphite Agent](https://app.graphite.com/background-agents/UWEZO-Creative-Hub/uwezo/task/bgt_01kec373akfrxr384ft07hkdjm)
